### PR TITLE
Fix exports object for browser entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   "types": "types.d.ts",
   "exports": {
     ".": {
+      "browser": {
+        "import": "./dist/sign-aws-requests-browser.js",
+        "require": "./dist/sign-aws-requests-browser.cjs"
+      },
       "import": "./dist/sign-aws-requests.js",
       "require": "./dist/sign-aws-requests.cjs"
     },


### PR DESCRIPTION
esbuild was respecting the exports object and preventing us from bundling the browser files.

I tested this locally with esbuild